### PR TITLE
Added: sibling, has and contains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cpcache
+.idea

--- a/src/hickory_css_selectors.clj
+++ b/src/hickory_css_selectors.clj
@@ -16,7 +16,7 @@
     ANY = <'*'>
     ELEM = NAME
     <NAME> = #'[A-Za-z0-9\\-\\_]+'
-    <SPEC> = ATTR | NTH_CHILD
+    <SPEC> = ATTR | NTH_CHILD | HAS_CHILD | HAS_TEXT
     ATTR = <'['> ATTR_BODY <']'>
     <ATTR_BODY> = NAME PRED?
     PRED = ATTR_OP VALUE
@@ -25,11 +25,15 @@
     <SYM> = #'[^\"\\'\\]]+'\n
     NTH_CHILD = <':nth-child('> NTH <')'>
     NTH = #'[0-9]+'
+    HAS_CHILD = <':has('> SELECTOR <')'>
+    HAS_TEXT = <':contains(\\''> TEXT_SQ <'\\')'> | <':contains(\"'> TEXT_DQ <'\")'>
+    <TEXT_SQ> = #'[^\\']*'
+    <TEXT_DQ> = #'[^\"]*'
     <PATH> = CHILD | DESCENDANT | SIBLING | NEXT_SIBLING
-    CHILD        = TOKEN <SPACE?> <'>'> <SPACE?> SELECTOR
-    DESCENDANT   = TOKEN <SPACE> SELECTOR
-    SIBLING      = TOKEN <SPACE?> <'~'> <SPACE?> SELECTOR
-    NEXT_SIBLING = TOKEN <SPACE?> <'+'> <SPACE?> SELECTOR
+    CHILD        = SELECTOR <SPACE?> <'>'> <SPACE?> TOKEN
+    DESCENDANT   = SELECTOR <SPACE> TOKEN
+    SIBLING      = SELECTOR <SPACE?> <'~'> <SPACE?> TOKEN
+    NEXT_SIBLING = SELECTOR <SPACE?> <'+'> <SPACE?> TOKEN
     <SPACE> = #'\\s+'"))
 
 (def syntax->selector
@@ -49,6 +53,8 @@
                      "~=" cs/includes?)
    :NTH_CHILD     s/nth-child
    :NTH           #(Integer/parseInt %)
+   :HAS_CHILD     s/has-child
+   :HAS_TEXT      (comp s/find-in-text re-pattern)
    :CHILD         s/child
    :DESCENDANT    s/descendant
    :SIBLING       s/follow

--- a/src/hickory_css_selectors.clj
+++ b/src/hickory_css_selectors.clj
@@ -9,63 +9,54 @@
   "An incomplete and not very good parser for CSS selectors.
   https://drafts.csswg.org/selectors-3/#selectors"
   (p/parser
-   "<S> = TOKEN (PATH S)*
+   "<SELECTOR> = TOKEN | PATH
     TOKEN = (ELEM ID? | CLASS | ID | ANY) CLASS* SPEC?
     CLASS = <'.'> NAME
     ID = <'#'> NAME
     ANY = <'*'>
     ELEM = NAME
+    <NAME> = #'[A-Za-z0-9\\-\\_]+'
     <SPEC> = ATTR | NTH_CHILD
-    NTH_CHILD = <':nth-child('> NTH <')'>
     ATTR = <'['> ATTR_BODY <']'>
     <ATTR_BODY> = NAME PRED?
-    NTH = #'[0-9]+'
     PRED = ATTR_OP VALUE
     ATTR_OP = '=' | '!=' | '~=' | '^=' | '$='
     VALUE = <'\"'> SYM <'\"'> | <#'\\''> SYM <#'\\''> | SYM
-    <SYM> = #'[^\"\\'\\]]+'
-    <NAME> = #'[A-Za-z0-9\\-\\_]+'
-    <PATH> = CHILD | DESCENDANT
-    CHILD = <SPACE?> <'>'> <SPACE?>
-    <DESCENDANT> = <' '>
+    <SYM> = #'[^\"\\'\\]]+'\n
+    NTH_CHILD = <':nth-child('> NTH <')'>
+    NTH = #'[0-9]+'
+    <PATH> = CHILD | DESCENDANT | SIBLING | NEXT_SIBLING
+    CHILD        = TOKEN <SPACE?> <'>'> <SPACE?> SELECTOR
+    DESCENDANT   = TOKEN <SPACE> SELECTOR
+    SIBLING      = TOKEN <SPACE?> <'~'> <SPACE?> SELECTOR
+    NEXT_SIBLING = TOKEN <SPACE?> <'+'> <SPACE?> SELECTOR
     <SPACE> = #'\\s+'"))
 
 (def syntax->selector
   "Map from parser tokens to Hickory selectors."
-  {:TOKEN     (fn [& ts] (apply s/and ts))
-   :CLASS     s/class
-   :ID        s/id
-   :ANY       (constantly s/any)
-   :ELEM      s/tag
-   :ATTR      (fn [attr & [pred]] (if pred (s/attr attr pred) (s/attr attr)))
-   :PRED      (fn [op [_ val]] #(op % val))
-   :ATTR_OP   #(case %
-                 "=" =
-                 "!=" not=
-                 "^=" cs/starts-with?
-                 "$=" cs/ends-with?
-                 "~=" cs/includes?)
-   :NTH_CHILD s/nth-child
-   :NTH       #(Integer/parseInt %)})
-
-(defn join-children
-  "Takes a sequence of selectors and returns it with child relations joined
-  e.g. 'x y > z a > b c' -> 'x (y > z) (a > b) c'"
-  ([tree] (join-children tree s/child))
-  ([tree join]
-   (loop [[curr & [next & more :as tail]] tree
-          children []
-          out []]
-     (cond
-       (not curr)        out
-       (= [:CHILD] next) (recur more (conj children curr) out)
-       (seq children)    (recur tail [] (conj out (apply join (conj children curr))))
-       :else             (recur tail children (conj out curr))))))
+  {:TOKEN         (fn [& ts] (apply s/and ts))
+   :CLASS         s/class
+   :ID            s/id
+   :ANY           (constantly s/any)
+   :ELEM          s/tag
+   :ATTR          (fn [attr & [pred]] (if pred (s/attr attr pred) (s/attr attr)))
+   :PRED          (fn [op [_ val]] #(op % val))
+   :ATTR_OP       #(case %
+                     "=" =
+                     "!=" not=
+                     "^=" cs/starts-with?
+                     "$=" cs/ends-with?
+                     "~=" cs/includes?)
+   :NTH_CHILD     s/nth-child
+   :NTH           #(Integer/parseInt %)
+   :CHILD         s/child
+   :DESCENDANT    s/descendant
+   :SIBLING       s/follow
+   :NEXT_SIBLING  s/follow-adjacent})
 
 (defn parse-css-selector
   "Builds a Hickory selector from given CSS selector string."
   [s]
   (->> (p/parse css-selector-parser s)
        (pt/transform syntax->selector)
-       (join-children)
-       (apply s/descendant)))
+       (first)))

--- a/test/hickory_css_selectors_test.clj
+++ b/test/hickory_css_selectors_test.clj
@@ -43,44 +43,48 @@
       [:TOKEN [:ID "foo"]]]]
     "body:nth-child(1)"
     [[:TOKEN [:ELEM "body"] [:NTH_CHILD [:NTH "1"]]]]
+    "div:has(p)"
+    [[:TOKEN [:ELEM "div"] [:HAS_CHILD [:TOKEN [:ELEM "p"]]]]]
+    "div:contains('bla')"
+    [[:TOKEN [:ELEM "div"] [:HAS_TEXT "bla"]]]
     ".foo.bar>#foo:nth-child(1)"
     [[:CHILD
       [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
       [:TOKEN [:ID "foo"] [:NTH_CHILD [:NTH "1"]]]]]
     "x > .y > #z a b > c"
     [[:CHILD
-       [:TOKEN [:ELEM "x"]]
-       [:CHILD
-         [:TOKEN [:CLASS "y"]]
-         [:DESCENDANT
-           [:TOKEN [:ID "z"]]
-           [:DESCENDANT
-             [:TOKEN [:ELEM "a"]]
-             [:CHILD
-               [:TOKEN [:ELEM "b"]]
-               [:TOKEN [:ELEM "c"]]]]]]]]
+      [:DESCENDANT
+       [:DESCENDANT
+        [:CHILD
+         [:CHILD
+          [:TOKEN [:ELEM "x"]]
+          [:TOKEN [:CLASS "y"]]]
+         [:TOKEN [:ID "z"]]]
+        [:TOKEN [:ELEM "a"]]]
+       [:TOKEN [:ELEM "b"]]]
+      [:TOKEN [:ELEM "c"]]]]
     "x y z"
     [[:DESCENDANT
-      [:TOKEN [:ELEM "x"]]
       [:DESCENDANT
-        [:TOKEN [:ELEM "y"]]
-        [:TOKEN [:ELEM "z"]]]]]
+       [:TOKEN [:ELEM "x"]]
+       [:TOKEN [:ELEM "y"]]]
+      [:TOKEN [:ELEM "z"]]]]
     "#readme > div.Box-body.p-6 > article > p:nth-child(19)"
     [[:CHILD
-       [:TOKEN [:ID "readme"]]
+      [:CHILD
        [:CHILD
-         [:TOKEN [:ELEM "div"] [:CLASS "Box-body"] [:CLASS "p-6"]]
-         [:CHILD
-           [:TOKEN [:ELEM "article"]]
-           [:TOKEN [:ELEM "p"] [:NTH_CHILD [:NTH "19"]]]]]]]
+        [:TOKEN [:ID "readme"]]
+        [:TOKEN [:ELEM "div"] [:CLASS "Box-body"] [:CLASS "p-6"]]]
+       [:TOKEN [:ELEM "article"]]]
+      [:TOKEN [:ELEM "p"] [:NTH_CHILD [:NTH "19"]]]]]
     "html > body > div > li:nth-child(2)"
     [[:CHILD
-       [:TOKEN [:ELEM "html"]]
+      [:CHILD
        [:CHILD
-         [:TOKEN [:ELEM "body"]]
-         [:CHILD
-           [:TOKEN [:ELEM "div"]]
-           [:TOKEN [:ELEM "li"] [:NTH_CHILD [:NTH "2"]]]]]]]))
+        [:TOKEN [:ELEM "html"]]
+        [:TOKEN [:ELEM "body"]]]
+       [:TOKEN [:ELEM "div"]]]
+      [:TOKEN [:ELEM "li"] [:NTH_CHILD [:NTH "2"]]]]]))
 
 (def tree
   (-> "<html><body>
@@ -94,7 +98,7 @@
         </div>
         <p>2</p>
         <span id='f'>g</span>
-        <div id='another-div'></div>
+        <div id='another-div'><div id='child-div'>find this text</div></div>
        </body></html>"
       (h/parse)
       (h/as-hickory)))
@@ -106,7 +110,12 @@
   (is (= ["italia"] (-> (select-css "div:nth-child(2) > i") first :content)))
   (is (= ["foo"] (-> (select-css "body ul > li:nth-child(2)") first :content)))
   (is (= ["2"] (-> (select-css "div#bar + p") first :content)))
-  (is (= ["bar" "another-div"] (map (comp :id :attrs) (select-css "p.some-class ~ div")))))
+  (is (= ["bar" "another-div"] (map (comp :id :attrs) (select-css "p.some-class ~ div"))))
+  (is (= "another-div" (-> (select-css "div:has(div)") first :attrs :id)))
+  (is (= "child-div" (-> (select-css "div:contains('find this')") first :attrs :id)))
+  (is (= "child-div" (-> (select-css "div:contains(\"find this\")") first :attrs :id)))
+  (is (= "bar" (-> (select-css "*:has(*:has(*:contains('foo')))") first :attrs :id)))
+  (is (= ["find this text"] (-> (select-css "span + div > div") first :content))))
 
 (comment
   (s/select (parse-css-selector "div:nth-child(2) > i") tree)
@@ -121,4 +130,6 @@
   (s/select (parse-css-selector "html > body > div > li:nth-child(2)") tree)
   (s/select (parse-css-selector "div:nth-child(2) > i") tree)
   (s/select (parse-css-selector "div + p") tree)
-  (s/select (parse-css-selector "div ~ p") tree))
+  (s/select (parse-css-selector "div ~ p") tree)
+  (s/select (parse-css-selector "div:has(div > p)") tree)
+  (s/select (parse-css-selector "div:contains('bla! bla*')") tree))

--- a/test/hickory_css_selectors_test.clj
+++ b/test/hickory_css_selectors_test.clj
@@ -26,56 +26,61 @@
     ".foo.bar.baz"
     [[:TOKEN [:CLASS "foo"] [:CLASS "bar"] [:CLASS "baz"]]]
     ".foo.bar > #foo"
-    [[:TOKEN [:CLASS "foo"] [:CLASS "bar"]] [:CHILD] [:TOKEN [:ID "foo"]]]
+    [[:CHILD
+      [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
+      [:TOKEN [:ID "foo"]]]]
+    ".foo.bar + #foo"
+    [[:NEXT_SIBLING
+      [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
+      [:TOKEN [:ID "foo"]]]]
+    ".foo.bar ~ #foo"
+    [[:SIBLING
+      [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
+      [:TOKEN [:ID "foo"]]]]
     ".foo.bar #foo"
-    [[:TOKEN [:CLASS "foo"] [:CLASS "bar"]] [:TOKEN [:ID "foo"]]]
+    [[:DESCENDANT
+      [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
+      [:TOKEN [:ID "foo"]]]]
     "body:nth-child(1)"
     [[:TOKEN [:ELEM "body"] [:NTH_CHILD [:NTH "1"]]]]
     ".foo.bar>#foo:nth-child(1)"
-    [[:TOKEN [:CLASS "foo"] [:CLASS "bar"]] [:CHILD] [:TOKEN [:ID "foo"] [:NTH_CHILD [:NTH "1"]]]]
+    [[:CHILD
+      [:TOKEN [:CLASS "foo"] [:CLASS "bar"]]
+      [:TOKEN [:ID "foo"] [:NTH_CHILD [:NTH "1"]]]]]
     "x > .y > #z a b > c"
-    [[:TOKEN [:ELEM "x"]]
-     [:CHILD]
-     [:TOKEN [:CLASS "y"]]
-     [:CHILD]
-     [:TOKEN [:ID "z"]]
-     [:TOKEN [:ELEM "a"]]
-     [:TOKEN [:ELEM "b"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "c"]]]
+    [[:CHILD
+       [:TOKEN [:ELEM "x"]]
+       [:CHILD
+         [:TOKEN [:CLASS "y"]]
+         [:DESCENDANT
+           [:TOKEN [:ID "z"]]
+           [:DESCENDANT
+             [:TOKEN [:ELEM "a"]]
+             [:CHILD
+               [:TOKEN [:ELEM "b"]]
+               [:TOKEN [:ELEM "c"]]]]]]]]
     "x y z"
-    [[:TOKEN [:ELEM "x"]] [:TOKEN [:ELEM "y"]] [:TOKEN [:ELEM "z"]]]
+    [[:DESCENDANT
+      [:TOKEN [:ELEM "x"]]
+      [:DESCENDANT
+        [:TOKEN [:ELEM "y"]]
+        [:TOKEN [:ELEM "z"]]]]]
     "#readme > div.Box-body.p-6 > article > p:nth-child(19)"
-    [[:TOKEN [:ID "readme"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "div"] [:CLASS "Box-body"] [:CLASS "p-6"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "article"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "p"] [:NTH_CHILD [:NTH "19"]]]]
+    [[:CHILD
+       [:TOKEN [:ID "readme"]]
+       [:CHILD
+         [:TOKEN [:ELEM "div"] [:CLASS "Box-body"] [:CLASS "p-6"]]
+         [:CHILD
+           [:TOKEN [:ELEM "article"]]
+           [:TOKEN [:ELEM "p"] [:NTH_CHILD [:NTH "19"]]]]]]]
     "html > body > div > li:nth-child(2)"
-    [[:TOKEN [:ELEM "html"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "body"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "div"]]
-     [:CHILD]
-     [:TOKEN [:ELEM "li"] [:NTH_CHILD [:NTH "2"]]]]))
-
-(deftest join-children-test
-  (are [css tree] (= tree (join-children (p/parse css-selector-parser css) list))
-    "x"
-    [[:TOKEN [:ELEM "x"]]]
-    "x y z"
-    [[:TOKEN [:ELEM "x"]] [:TOKEN [:ELEM "y"]] [:TOKEN [:ELEM "z"]]]
-    "x y > z a > b c"
-    '[[:TOKEN [:ELEM "x"]]
-      ([:TOKEN [:ELEM "y"]] [:TOKEN [:ELEM "z"]])
-      ([:TOKEN [:ELEM "a"]] [:TOKEN [:ELEM "b"]])
-      [:TOKEN [:ELEM "c"]]]
-    "html > body div > li:nth-child(2)"
-    '[([:TOKEN [:ELEM "html"]] [:TOKEN [:ELEM "body"]])
-      ([:TOKEN [:ELEM "div"]] [:TOKEN [:ELEM "li"] [:NTH_CHILD [:NTH "2"]]])]))
+    [[:CHILD
+       [:TOKEN [:ELEM "html"]]
+       [:CHILD
+         [:TOKEN [:ELEM "body"]]
+         [:CHILD
+           [:TOKEN [:ELEM "div"]]
+           [:TOKEN [:ELEM "li"] [:NTH_CHILD [:NTH "2"]]]]]]]))
 
 (def tree
   (-> "<html><body>
@@ -99,7 +104,9 @@
 (deftest select-test
   (is (= "bar" (-> (select-css "div#bar") first :attrs :id)))
   (is (= ["italia"] (-> (select-css "div:nth-child(2) > i") first :content)))
-  (is (= ["foo"] (-> (select-css "body ul > li:nth-child(2)") first :content))))
+  (is (= ["foo"] (-> (select-css "body ul > li:nth-child(2)") first :content)))
+  (is (= ["2"] (-> (select-css "div#bar + p") first :content)))
+  (is (= ["bar" "another-div"] (map (comp :id :attrs) (select-css "p.some-class ~ div")))))
 
 (comment
   (s/select (parse-css-selector "div:nth-child(2) > i") tree)
@@ -112,4 +119,6 @@
   (s/select (parse-css-selector "html>body>div li:nth-child(2)") tree)
   (s/select (parse-css-selector "body ul > li:nth-child(2)") tree)
   (s/select (parse-css-selector "html > body > div > li:nth-child(2)") tree)
-  (s/select (parse-css-selector "div:nth-child(2) > i") tree))
+  (s/select (parse-css-selector "div:nth-child(2) > i") tree)
+  (s/select (parse-css-selector "div + p") tree)
+  (s/select (parse-css-selector "div ~ p") tree))


### PR DESCRIPTION
Introduced new css operators: `+`, `~`, `:has` and `:contains`.

DESCENDANT (` `) and CHILD (`>`) tokens now evaluate to a recursive structure so they can be mapped via `syntax->selector` like other tokens. `join-children` is not necessary anymore.